### PR TITLE
use ember install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Display a list of deployed revisions using [ember-cli-deploy](https://github.com
 
 ## Installation
 
-* `npm install ember-cli-deploy-display-revisions`
+* `ember install ember-cli-deploy-display-revisions`
 
 ## Usage
 


### PR DESCRIPTION
blindly copy pasting the old version won't update package.json hence the plugin will not be used in the pipeline, 
was a stupid mistake on my part but I think this could help